### PR TITLE
Bug Fix: Now view Once Messages can be used on 'getBase64FromMediaMessage' endpoint

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -1044,7 +1044,15 @@ export class WAStartupService {
       if (msg.message?.documentWithCaptionMessage) {
         msg.message = msg.message.documentWithCaptionMessage.message;
       }
-
+	  
+	  if (msg.message?.viewOnceMessage) {
+        msg.message = msg.message.viewOnceMessage.message;
+      }
+      
+      if (msg.message?.viewOnceMessageV2) {
+        msg.message = msg.message.viewOnceMessageV2.message;
+      }
+	  
       const typeMessage = [
         'imageMessage',
         'documentMessage',


### PR DESCRIPTION
Endpoint 'getBase64FromMediaMessage' was not able to return media from view Once Messages, this has been fixed.