### PR TITLE
Evitar a reconexão após o limite do QRCode

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -271,6 +271,11 @@ export class WAStartupService {
 
         delete this.client.ev.on;
 
+        this.client.end({
+          name: 'qrCodeLimitReached',
+          message: 'QR code limit reached, please login again',
+        });
+
         return this.eventEmitter.emit('no.connection', this.instance.name);
       }
 
@@ -318,7 +323,9 @@ export class WAStartupService {
 
     if (connection === 'close') {
       const shouldReconnect =
-        (lastDisconnect.error as Boom)?.output?.statusCode !== DisconnectReason.loggedOut;
+        (lastDisconnect.error as Boom)?.output?.statusCode !==
+          DisconnectReason.loggedOut &&
+        (lastDisconnect.error as Boom)?.name !== 'qrCodeLimitReached';
       if (shouldReconnect) {
         await this.connectToWhatsapp();
       } else {


### PR DESCRIPTION
Quando se cria uma nova instancia e conecta é não ler o QRCode ainda e possível receber o evento  QR code limit reached, please login again com o statusCode 500 Essa pequena alteração resolve esse problema.