### PR TITLE
Change webhook.controller.ts to allow non tld urls

### DIFF
--- a/src/whatsapp/controllers/webhook.controller.ts
+++ b/src/whatsapp/controllers/webhook.controller.ts
@@ -8,7 +8,7 @@ export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 
   public async createWebhook(instance: InstanceDto, data: WebhookDto) {
-    if (!isURL(data.url)) {
+    if (!isURL(data.url, {"require_tld": false})) {
       throw new BadRequestException('Invalid "url" property');
     }
     return this.webhookService.create(instance, data);


### PR DESCRIPTION
this will allow the usage of docker hostnames as webhooks

> a.isURL("http://django:8000")
false
> a.isURL("http://django.localhost:8000")
true
> a.isURL("http://django:8000", {"require_tld": false})
true
> a.isURL("http://111", {"require_tld": false})
false
> a.isURL("http://django", {"require_tld": false})
true