### PR TITLE
feat: docker.sh create folder /data/instances if doesnt exists

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -3,15 +3,19 @@
 NET='codechat-net'
 IMAGE='codechat/api:local'
 
-if !(docker network ls | grep ${NET} > /dev/null)
+# Check if the network exists and create it if not
+if !(docker network ls | grep -q ${NET})
 then
   docker network create -d bridge ${NET}
 fi
 
-sudo mkdir -p /data/instances
+# Create the directory for the bind mount if it does not exist
+if [ ! -d "/data/instances" ]; then
+  sudo mkdir -p /data/instances
+fi
 
+# Build the Docker image
 docker build -t ${IMAGE} .
 
-# docker run --restart 'always' --name 'codechat_api' --mount 'type=bind,source=/data/instances,target=/home/api/instances' --publish '8083:8083' --hostname 'codechat' --network ${NET} ${IMAGE}
-
+# Run the Docker container
 docker run -d --restart 'always' --name 'codechat_api' --mount 'type=bind,source=/data/instances,target=/codechat/instances' --publish '8083:8083' --hostname 'codechat' --network ${NET} ${IMAGE}


### PR DESCRIPTION
This PR is about the error, when you try to up the project with docker, via docker.sh

After all instalation, if you dont have the "/data/instances" folder

The last command dont run the image

For reproduce this error, just try run the docker.sh in new vps.

I got this error

docker: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /data/instances.