### PR TITLE
enable quoted option in send message to reply a message

### DIFF
--- a/src/whatsapp/dto/sendMessage.dto.ts
+++ b/src/whatsapp/dto/sendMessage.dto.ts
@@ -3,6 +3,7 @@ import { proto, WAPresence } from '@whiskeysockets/baileys';
 export class Options {
   delay?: number;
   presence?: WAPresence;
+  quoted?: proto.IWebMessageInfo;
 }
 class OptionsMessage {
   options: Options;

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -880,12 +880,18 @@ export class WAStartupService {
 
       const messageSent = await (async () => {
         if (!message['audio']) {
-          return await this.client.sendMessage(sender, {
-            forward: {
-              key: { remoteJid: this.instance.wuid, fromMe: true },
-              message,
+          return await this.client.sendMessage(
+            sender,
+            {
+              forward: {
+                key: { remoteJid: this.instance.wuid, fromMe: true },
+                message,
+              },
             },
-          });
+            {
+              quoted: options?.quoted || null,
+            },
+          );
         }
 
         return await this.client.sendMessage(


### PR DESCRIPTION
This feature allows users to mention a message sending the original message as a parameter in options object.