### PR TITLE
Update monitor.service.ts

### DIFF
--- a/src/whatsapp/services/monitor.service.ts
+++ b/src/whatsapp/services/monitor.service.ts
@@ -161,12 +161,14 @@ export class WAMonitoringService {
   private removeInstance() {
     this.eventEmitter.on('remove.instance', async (instance: Instance) => {
       try {
-        await this.waInstances.get(instance.name)?.client?.logout();
-        this.waInstances
-          .get(instance.name)
-          ?.client?.ev.removeAllListeners('connection.update');
-        this.waInstances.get(instance.name)?.client?.ev.flush();
-        this.waInstances.delete(instance.name);
+        if (instance) {
+          await this.waInstances.get(instance.name)?.client?.logout();
+          this.waInstances
+            .get(instance.name)
+            ?.client?.ev.removeAllListeners('connection.update');
+          this.waInstances.get(instance.name)?.client?.ev.flush();
+          this.waInstances.delete(instance.name);
+        }
       } catch (error) {
         this.logger.subContext('removeInstance');
         this.logger.error(error);
@@ -174,7 +176,9 @@ export class WAMonitoringService {
       }
 
       try {
-        await this.cleaningUp(instance);
+        if (instance) {
+          await this.cleaningUp(instance);
+        }
       } finally {
         this.logger.warn(`Instance "${instance?.name}" - REMOVED`);
       }


### PR DESCRIPTION
A falta de verificação do objeto 'instance' no método removeInstance, estava acarretando o erro "TypeError: Cannot destructure property 'name' of 'object null' as it is null."