### PR TITLE
Fix: qrcode trigger limit

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -339,7 +339,7 @@ export class WAStartupService {
     lastDisconnect,
   }: Partial<ConnectionState>) {
     if (qr) {
-      if (this.qrCode === this.configService.get<QrCode>('QRCODE').LIMIT) {
+      if (this.qrCode.count === this.configService.get<QrCode>('QRCODE').LIMIT) {
         this.sendDataWebhook('qrcodeUpdated', {
           message: 'QR code limit reached, please login again',
           statusCode: DisconnectReason.badSession,


### PR DESCRIPTION
# Motivation

Currently, the code is not respecting the limit for connection QR Code generation attempts. This happens because the conditional statement is written incorrectly.