### PR TITLE
Fix: Correção no envio do evento webhook

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -989,6 +989,10 @@ export class WAStartupService {
         5: 'PLAYED',
       };
       for await (const { key, update } of args) {
+        if (update.status === 4 && key?.remoteJid) {
+          key.remoteJid = key.remoteJid.replace(/:\d+(?=@)/, '');
+        }
+
         if (key.remoteJid !== 'status@broadcast' && !key?.remoteJid?.match(/(:\d+)/)) {
           const message = {
             ...key,


### PR DESCRIPTION
## Motivação
Atualmente, quando o evento de leitura da mensagem é oriundo de um whatsapp web, o webhook não envia esse evento.
## Correção
Correção no envio de eventos `messages.update` com status 'READ'.