### PR TITLE
Fix external attributes

### DIFF
--- a/prisma/migrations/20250315000432_add_external_attributes/migration.sql
+++ b/prisma/migrations/20250315000432_add_external_attributes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN "externalAttributes" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,21 +88,22 @@ enum DeviceMessage {
 }
 
 model Message {
-  id               Int             @id @default(autoincrement())
-  keyId            String          @db.VarChar(100)
-  keyRemoteJid     String          @db.VarChar(100)
-  keyFromMe        Boolean         @db.Boolean
-  keyParticipant   String?         @db.VarChar(100)
-  pushName         String?         @db.VarChar(100)
-  messageType      String          @db.VarChar(100)
-  content          Json            @db.JsonB
-  messageTimestamp Int             @db.Integer
-  device           DeviceMessage
-  isGroup          Boolean?        @db.Boolean
-  Instance         Instance        @relation(fields: [instanceId], references: [id], onDelete: Cascade)
-  instanceId       Int
-  MessageUpdate    MessageUpdate[]
-  Media            Media?
+  id                  Int             @id @default(autoincrement())
+  keyId               String          @db.VarChar(100)
+  keyRemoteJid        String          @db.VarChar(100)
+  keyFromMe           Boolean         @db.Boolean
+  keyParticipant      String?         @db.VarChar(100)
+  pushName            String?         @db.VarChar(100)
+  messageType         String          @db.VarChar(100)
+  content             Json            @db.JsonB
+  messageTimestamp    Int             @db.Integer
+  device              DeviceMessage
+  isGroup             Boolean?        @db.Boolean
+  Instance            Instance        @relation(fields: [instanceId], references: [id], onDelete: Cascade)
+  instanceId          Int
+  MessageUpdate       MessageUpdate[]
+  Media               Media?
+  externalAttributes  Json?          @db.JsonB
 
   @@index([keyId], name: "keyId")
 }

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -1331,6 +1331,7 @@ export class WAStartupService {
           device: 'web',
           isGroup: isJidGroup(m.key.remoteJid),
           typebotSessionId: undefined,
+          externalAttributes: options?.externalAttributes
         };
       })();
       if (this.databaseOptions.DB_OPTIONS.NEW_MESSAGE) {
@@ -1339,8 +1340,6 @@ export class WAStartupService {
         });
         messageSent.id = id;
       }
-
-      messageSent['externalAttributes'] = options?.externalAttributes;
 
       this.ws.send(this.instance.name, 'send.message', messageSent);
       this.sendDataWebhook('sendMessage', messageSent).catch((error) =>
@@ -2273,6 +2272,7 @@ export class WAStartupService {
         messageTimestamp: true,
         instanceId: true,
         device: true,
+        externalAttributes: true,
         MessageUpdate: {
           select: {
             status: true,


### PR DESCRIPTION
So I made an attempt to add externalAttributes to messages which would probably solve #168.

More testing needs to be done, as I did only test it within Swagger. The field is a JsonB field, similar to the "content" one, so it could accept arrays as well if necessary.

I'll test it tomorrow on our development servers to see if it works in a real life scenario, but the storage of the externalAttributes is working already. Didn't test the webhook, but fetchMessages does work as well.

**Needs more testing, but PR is here for review**