### PR TITLE
Fix error 500 when using request params

### DIFF
--- a/src/validate/router.validate.ts
+++ b/src/validate/router.validate.ts
@@ -64,7 +64,7 @@ export function routerPath(path: string, param = true) {
 export async function dataValidate<T>(args: DataValidate<T>) {
   const { request, schema, execute } = args;
 
-  const body = request.body;
+  const body = request.body ?? {};
   const instance = request.params as unknown as InstanceDto;
 
   const isNotEmptyQuery = request?.query && Object.keys(request.query).length > 0;
@@ -119,7 +119,7 @@ export async function groupValidate<T>(args: DataValidate<T>) {
   }
 
   const instance = request.params as unknown as InstanceDto;
-  const body = request.body;
+  const body = request.body ?? {};
 
   Object.assign(body, groupJid);
 


### PR DESCRIPTION
Depois de atualizar a API para 1.3.5, o endpoint /instance/delete parou de funcionar… 

  Só retorna erro 500, mas não vejo nenhum mensagem de erro no cliente ou no servidor…

Uma coisa que reparei, ambos os endpoints funcionam normalmente se eu n passar nenhum parâmetro…
  . DELETE /instance/delete/<instanceName>
  . GET /instance/fetchInstances/

Mas se adiciono parâmetro (force ou instanceName=), o erro 500 aparecia

Com essa alteração, o problema foi resolvido no meu lado aqui...