### PR TITLE
Bugfix: cannot read properties of undefined

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -906,7 +906,7 @@ export class WAStartupService {
           keyParticipant:
             received?.participant || this.normalizeParticipant(received.key),
           messageType,
-          content: received.message[messageType] as PrismType.Prisma.JsonValue,
+          content: JSON.parse(JSON.stringify(received.message[messageType])) as PrismType.Prisma.JsonValue,
           messageTimestamp: timestamp,
           instanceId: this.instance.id,
           device: (() => {
@@ -1393,7 +1393,7 @@ export class WAStartupService {
           keyParticipant: m?.participant,
           pushName: m?.pushName,
           messageType: getContentType(m.message),
-          content: m.message[getContentType(m.message)] as PrismType.Prisma.JsonValue,
+          content: JSON.parse(JSON.stringify(m.message[getContentType(m.message)])) as PrismType.Prisma.JsonValue,
           messageTimestamp: timestamp,
           instanceId: this.instance.id,
           device: 'web',


### PR DESCRIPTION
Uma simples correção, havia muitas mensagens "cannot read properties of undefined", evitado agora com o uso de operadores.
Também atualização do código para compatibilidade com o Baileys 7.0.0.rc-6